### PR TITLE
Revert timeout update

### DIFF
--- a/config/rev_map/patient_page.py
+++ b/config/rev_map/patient_page.py
@@ -67,12 +67,11 @@ class PatientPage(BasePage):
         try:
             self.page.goto(self.base_url)
             self.logger.log("Navigated to patient search page")
-
-            # Wait for the page and dynamic content to load
-            if not self.wait_for_page_ready():
-                raise Exception("Patient page failed to load after navigation")
-
-            # Verify required elements
+            
+            # Add a small delay to ensure the page has time to load
+            self.page.wait_for_timeout(2000)  # 2 second delay
+            
+            # Wait for the page to be loaded
             if not self.is_loaded():
                 raise Exception("Patient page failed to load after navigation")
                 

--- a/config/rev_map/rev_session.py
+++ b/config/rev_map/rev_session.py
@@ -11,7 +11,7 @@ from .claims_page import ClaimsPage
 import os
 import time
 
-class RevSession(BasePage):
+class RevSession:
     """Class for managing Revolution EHR session and page interactions."""
     
     class _Pages:
@@ -29,13 +29,15 @@ class RevSession(BasePage):
     
     def __init__(self, page: Page, logger: Logger, context: Optional[PatientContext] = None):
         """Initialize the Revolution EHR session.
-
+        
         Args:
             page: Playwright page instance
             logger: Logger instance for logging operations
             context: Optional PatientContext for patient-specific operations
         """
-        super().__init__(page, logger, context)
+        self.page = page
+        self.logger = logger
+        self.context = context
         self.pages = self._Pages(page, logger, context)
     
     def login(self) -> None:
@@ -61,8 +63,9 @@ class RevSession(BasePage):
         # Click the login button
         self.page.locator('[data-test-id="loginBtn"]').click()
         
-        # Wait for the login page to fully load
-        self.wait_for_page_ready()
+        # Wait for navigation to complete
+        self.page.wait_for_load_state("networkidle")
+        time.sleep(2)  # Additional small delay to ensure page is fully loaded
         
         self.logger.log("✅ Logged into RevolutionEHR")
     

--- a/core/base.py
+++ b/core/base.py
@@ -271,31 +271,6 @@ class BasePage:
             self.logger.log_error(f"Network idle wait failed: {str(e)}")
             return False
 
-    def wait_for_page_ready(self, selectors: Optional[List[str]] = None, timeout: int = 15000) -> bool:
-        """Wait for the page to be fully loaded and dynamic content to settle.
-
-        Args:
-            selectors: Optional list of CSS selectors that should be visible once
-                the page is ready.
-            timeout: Maximum wait time in milliseconds.
-
-        Returns:
-            bool: True if the page is ready within the timeout, False otherwise.
-        """
-        selectors = selectors or []
-        try:
-            self.page.wait_for_load_state("load", timeout=timeout)
-            self.page.wait_for_function(
-                "() => document.readyState === 'complete' && (!window.jQuery || jQuery.active === 0)",
-                timeout=timeout,
-            )
-            for selector in selectors:
-                self.page.locator(selector).wait_for(state="visible", timeout=timeout)
-            return True
-        except Exception as e:
-            self.logger.log_error(f"Page ready wait failed: {str(e)}")
-            return False
-
 class PatientManager:
     def __init__(self):
         self._patients: Dict[str, Patient] = {}


### PR DESCRIPTION
## Summary
- revert latest timeout handling and page load logic

## Testing
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6841b28d2758832284bbb9d0aa55e2d8