### PR TITLE
Add optical order detection

### DIFF
--- a/config/rev_map/invoice_page.py
+++ b/config/rev_map/invoice_page.py
@@ -7,6 +7,7 @@ from core.base import BasePage, PatientContext, PatientManager, Patient
 import re
 from bs4 import BeautifulSoup
 from core.base import ClaimItem
+from core.utils import has_glasses_order, has_frame_claim
 
 class InvoicePage(BasePage):
     def __init__(
@@ -744,6 +745,10 @@ class InvoicePage(BasePage):
                     modifier=row['modifiers'] if row['modifiers'] else None
                 )
                 patient.claims.append(claim_item)
+
+            # Determine if this invoice contains optical orders
+            patient.has_optical_order = has_glasses_order(patient)
+            patient.has_frame = has_frame_claim(patient)
 
             # Store DOS in insurance_data
             if data_rows:

--- a/core/base.py
+++ b/core/base.py
@@ -41,6 +41,10 @@ class Patient:
     frames: Dict[str, Any] = field(default_factory=dict)
     lenses: Dict[str, Any] = field(default_factory=dict)
     contacts: Dict[str, Any] = field(default_factory=dict)
+
+    # Flags for invoice type
+    has_optical_order: bool = False
+    has_frame: bool = False
     
     def __post_init__(self):
         """Convert dob string to datetime if needed"""

--- a/core/utils.py
+++ b/core/utils.py
@@ -94,41 +94,42 @@ def set_copay(patient: Patient) -> None:
 
 def has_glasses_order(patient: Patient) -> bool:
     """Check if a patient has any claims indicating a glasses order.
-    
-    This function checks for V21 or V22 codes in the patient's claims,
-    which indicate a glasses order in the system.
-    
+
+    The check is case-insensitive and looks for base lens codes such as
+    ``V21xx``, ``V22xx``, ``V23xx`` or the specific ``V2781`` code.
+
     Args:
         patient: Patient object containing claims to check
-        
+
     Returns:
         bool: True if a glasses order is found, False otherwise
     """
     if not hasattr(patient, 'claims') or not patient.claims:
         return False
-        
+
+    pattern = re.compile(r"^v(?:21\d\d|22\d\d|23\d\d|2781)$", re.IGNORECASE)
     for claim in patient.claims:
-        if claim.code.startswith('V21') or claim.code.startswith('V22'):
+        if claim.code and pattern.match(claim.code.strip()):
             return True
-            
+
     return False
 
 def has_frame_claim(patient: Patient) -> bool:
-    """Check if the patient has a frame claim by looking for V202 codes.
-    
+    """Check if the patient has a frame claim by looking for the V2020 code.
+
     Args:
         patient: Patient object containing claims data
-        
+
     Returns:
         bool: True if a frame claim is found, False otherwise
     """
     if not patient.claims:
         return False
-        
+
     for claim in patient.claims:
-        if claim.code and claim.code.upper().startswith('V202'):
+        if claim.code and claim.code.strip().upper() == 'V2020':
             return True
-            
+
     return False
 
 def get_page_soup(page) -> BeautifulSoup:


### PR DESCRIPTION
## Summary
- extend `Patient` dataclass with optical order flags
- broaden claim utilities for detecting lens and frame codes
- use detection in invoice scraping to set new flags

## Testing
- `python -m py_compile core/base.py core/utils.py config/rev_map/invoice_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68473fc417808322bb0f570214b91a30