### PR TITLE
Implement service selection based on claim codes

### DIFF
--- a/tests/test_service_selection.py
+++ b/tests/test_service_selection.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from config.vsp_map.authorization_page import AuthorizationPage
+from core.base import Patient
+from core.logger import Logger
+
+class DummyPage:
+    pass
+
+def build_page():
+    return AuthorizationPage(DummyPage(), Logger())
+
+
+def test_exam_and_contacts():
+    patient = Patient(first_name="A", last_name="B")
+    patient.add_claim_item(vcode="92014", description="Exam", billed_amount=1.0, code="92014")
+    patient.add_claim_item(vcode="V2520", description="Contacts", billed_amount=1.0, code="V2520")
+
+    page = build_page()
+    indices = page._services_from_claims(patient)
+    assert set(indices) == {0, 4}
+
+
+def test_frame_and_lens():
+    patient = Patient(first_name="A", last_name="B")
+    patient.add_claim_item(vcode="V2020", description="Frame", billed_amount=1.0, code="V2020")
+    patient.add_claim_item(vcode="V2100", description="Lens", billed_amount=1.0, code="V2100")
+
+    page = build_page()
+    indices = page._services_from_claims(patient)
+    assert set(indices) == {2, 3}


### PR DESCRIPTION
## Summary
- decide which authorization services to select based on patient claim codes
- expose helper to select services for a patient
- add basic tests for service selection logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6849a950bdcc8322bb9081a2ea740471