### PR TITLE
Enhance invoice scraping for service date and copay

### DIFF
--- a/core/base.py
+++ b/core/base.py
@@ -17,6 +17,12 @@ class ClaimItem:
     code: str  # CPT or Dx code
     quantity: int = 1
     modifier: Optional[str] = None
+    # Date of service for the claim item. Stored as the post date
+    # scraped from the invoice details page.
+    date: Optional[str] = None
+    # Copay amount associated with the claim item. This is derived from
+    # the "Adjustments" column on the invoice details table.
+    copay: Optional[str] = None
 
 @dataclass
 class Patient:


### PR DESCRIPTION
## Summary
- extend `ClaimItem` dataclass with `date` and `copay` fields
- parse service date and copay from invoice details
- include these values when creating claim items

## Testing
- `python -m py_compile core/base.py config/rev_map/invoice_page.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae5e1d6e4832298663bbc4d227f91