### PR TITLE
Handle disabled Issue Authorization button

### DIFF
--- a/config/vsp_map/authorization_page.py
+++ b/config/vsp_map/authorization_page.py
@@ -541,10 +541,19 @@ class AuthorizationPage(BasePage):
             self.logger.log_error(f"Failed to select all services: {str(e)}")
 
     def issue_authorization(self, package_index: int = 0) -> bool:
-        """Click the Issue Authorization button."""
+        """Click the Issue Authorization button.
+
+        The button may be visible but disabled (grayed out). In that case the
+        click should be skipped and ``False`` returned.
+        """
         try:
             button = self.page.locator(f'[id="0-issue-authorization-button"]')
             button.wait_for(state="visible", timeout=5000)
+
+            if not button.is_enabled():
+                self.logger.log_error("Issue Authorization button is disabled")
+                return False
+
             button.click()
             return True
         except Exception as e:


### PR DESCRIPTION
## Summary
- prevent issuing authorization if the button is disabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_688d22e0384c8322bd624d0e7b772131