### PR TITLE
Add LLM post-processing to search data

### DIFF
--- a/core/ai_tools/agent_instructions/instruction.txt
+++ b/core/ai_tools/agent_instructions/instruction.txt
@@ -1,0 +1,1 @@
+Organize this search data


### PR DESCRIPTION
## Summary
- extend MemberSearch.build_search_data to call an LLM via `OllamaClient`
- read post-processing instructions from `instruction.txt`
- include example instruction file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2', OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d2c9f0c488322beb544f564961a19