### PR TITLE
Stop claim submission when authorization fails

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,46 +148,43 @@ if __name__ == "__main__":
         else:
             print("Authorization could not be issued, skipping claim")
 
-
     if claim_ready:
         sleep(2)
         vsp.claim_page.set_dos(patient)
         vsp.claim_page.set_doctor(patient)
+
+        # Exam submission
+        if flags["exam"]:
+            vsp.claim_page.submit_exam(patient)
+
+        # Glasses related processing
+        if flags["lens"]:
+            vsp.claim_page.submit_frame(patient)
+            vsp.claim_page.submit_lens(patient)
+            vsp.claim_page.send_rx(patient)
+
+        # Contact lens materials or services
+        if flags["contacts"]:
+            vsp.claim_page.submit_cl(patient)
+
+        sleep(.5)
+        vsp.claim_page.disease_reporting(patient)
+        sleep(.5)
+        vsp.claim_page.calculate(patient)
+        sleep(.5)
+        vsp.claim_page.fill_pricing(patient)
+        sleep(.5)
+        vsp.claim_page.set_gender(patient)
+        sleep(.5)
+        vsp.claim_page.fill_address(patient)
+        sleep(.5)
+        success = vsp.claim_page.click_submit_claim()
+        if not success:
+            pass
+        print("returning  to  patient  page")
+        print('done')
     else:
         print("Claim page not ready, skipping claim submission")
-
-    # Exam submission
-    if flags["exam"]:
-        vsp.claim_page.submit_exam(patient)
-
-    # Glasses related processing
-
-       
-    if flags["lens"]:
-        vsp.claim_page.submit_frame(patient)
-        vsp.claim_page.submit_lens(patient)
-        vsp.claim_page.send_rx(patient)
-
-
-    # Contact lens materials or services
-    if flags["contacts"]:
-        vsp.claim_page.submit_cl(patient)
-    sleep(.5)
-    vsp.claim_page.disease_reporting(patient) 
-    sleep(.5)
-    vsp.claim_page.calculate(patient)
-    sleep(.5)
-    vsp.claim_page.fill_pricing(patient)
-    sleep(.5)
-    vsp.claim_page.set_gender(patient)
-    sleep(.5)
-    vsp.claim_page.fill_address(patient)
-    sleep(.5)
-    success = vsp.claim_page.click_submit_claim()
-    if not success:
-        pass
-    print("returning  to  patient  page")
-    print('done')
 
     
 


### PR DESCRIPTION
## Summary
- guard claim submission logic behind `claim_ready` flag to prevent frame/lens submission when authorization can't be issued

## Testing
- `pytest` *(fails: No module named 'PyPDF2'; missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6891111449d08322a5e45dde2788590c