### PR TITLE
Upload VSP report screenshot to invoice documents

### DIFF
--- a/config/vsp_map/claim_page.py
+++ b/config/vsp_map/claim_page.py
@@ -14,6 +14,8 @@ class ClaimPage(BasePage):
     def __init__(self, page: Page, logger: Logger, context: Optional[PatientContext] = None):
         super().__init__(page, logger, context)
         self.base_url = "https://eclaim.eyefinity.com/secure/eInsurance/claim-form"
+        # Path to the most recent popup screenshot, if any
+        self.last_screenshot_path: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Utilities
@@ -1002,6 +1004,8 @@ class ClaimPage(BasePage):
                 screenshot_path = f"logs/screenshots/vsp_reports_{int(time.time())}.png"
                 reports_page.screenshot(path=screenshot_path)
                 self.logger.log(f"Reports page screenshot saved: {screenshot_path}")
+                # Store path for later retrieval
+                self.last_screenshot_path = screenshot_path
             except Exception as e:
                 self.logger.log(f"Failed to take screenshot: {str(e)}")
             
@@ -1324,6 +1328,8 @@ class ClaimPage(BasePage):
         """
         try:
             self.logger.log("Starting claim submission process...")
+            # Reset stored screenshot path for this submission attempt
+            self.last_screenshot_path = None
             previous_url = self.page.url
 
             # Step 1: Click the initial submit claim button

--- a/submit_claims.py
+++ b/submit_claims.py
@@ -170,7 +170,17 @@ def process_invoice(invoice_id: str, rev: RevSession, vsp: VspSession) -> None:
     sleep(0.5)
     vsp.claim_page.fill_address(patient)
     sleep(0.5)
-    vsp.claim_page.click_submit_claim()
+    success = vsp.claim_page.click_submit_claim()
+
+    screenshot_path = vsp.claim_page.last_screenshot_path
+    if success and screenshot_path:
+        rev.invoice_page.navigate_to_invoices_page()
+        rev.invoice_page.search_invoice(invoice_number=invoice_id)
+        sleep(1)
+        rev.invoice_page.open_invoice(invoice_id)
+        rev.invoice_page.click_docs_and_images_tab()
+        rev.insurance_tab.upload_insurance_document(screenshot_path)
+
     rev.invoice_page.close_invoice_tabs(invoice_id)
 
 


### PR DESCRIPTION
## Summary
- Track claim popup screenshots in `ClaimPage` and reset for each submission
- After submitting a claim, reopen the invoice and upload the screenshot to the insurance documents folder

## Testing
- `pytest -q` *(fails: No module named 'PyPDF2')*
- `pytest -q` with `OPENAI_API_KEY=dummy` *(fails: No module named 'PyPDF2'; connection error to OpenAI)*

------
https://chatgpt.com/codex/tasks/task_e_689272669a1083229585ff957ed17277