### PR TITLE
Add logging around Ollama data scrubbing

### DIFF
--- a/config/vsp_map/member_search_page.py
+++ b/config/vsp_map/member_search_page.py
@@ -430,14 +430,19 @@ class MemberSearch(BasePage):
                 with open(instruction_file, "r") as f:
                     instruction = f.read()
 
+                self.logger.log(f"Dataset before LLM cleaning: {json.dumps(unique_data, indent=2)}")
                 client = OllamaClient()
                 prompt = f"{instruction}\n\n{json.dumps(unique_data)}"
+                start_time = time.time()
                 response = client.generate(prompt)
+                elapsed = time.time() - start_time
+                self.logger.log(f"Ollama model execution time: {elapsed:.2f} seconds")
 
                 if response:
                     cleaned = json.loads(response)
                     if isinstance(cleaned, list):
                         unique_data = cleaned
+                self.logger.log(f"Dataset after LLM cleaning: {json.dumps(unique_data, indent=2)}")
             except Exception as e:
                 self.logger.log(f"LLM processing failed: {e}")
         self.logger.log('LLM post-processing complete')


### PR DESCRIPTION
## Summary
- log the dataset before sending it to the Ollama-based cleaner
- measure and log the time taken by the model to scrub data
- log the cleaned dataset returned by the model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2'; openai.APIConnectionError: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68937b3c9d248322a00537706062f33c